### PR TITLE
Adds OpenTelemetry support for observability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,9 @@ CALENDAR_STORAGE_PATH=./data/calendars
 
 # MCP Sequential Thinking Tools
 MAX_HISTORY_SIZE=1000
+
+# OpenTelemetry Configuration
+ENABLE_OTEL=true
+ENABLE_SENSITIVE_DATA=true
+# OTLP_ENDPOINT=http://localhost:4317
+APPLICATIONINSIGHTS_CONNECTION_STRING=InstrumentationKey=your_key_from_azure_ai_foundry

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,13 @@ dependencies = [
     "icalendar>=5.0.11",
     "pytz>=2024.1",
     "rich>=13.7.0",
+    # OpenTelemetry packages for observability
+    "opentelemetry-api",
+    "opentelemetry-sdk",
+    "azure-monitor-opentelemetry",
+    "azure-monitor-opentelemetry-exporter>=1.0.0b41",
+    "opentelemetry-exporter-otlp-proto-grpc",
+    "opentelemetry-semantic-conventions-ai",
 ]
 
 [project.scripts]

--- a/src/spec_to_agents/console.py
+++ b/src/spec_to_agents/console.py
@@ -26,6 +26,7 @@ from agent_framework import (
     WorkflowRunState,
     WorkflowStatusEvent,
 )
+from agent_framework.observability import setup_observability
 from dotenv import load_dotenv
 
 from spec_to_agents.models.messages import HumanFeedbackRequest
@@ -44,6 +45,9 @@ from spec_to_agents.workflow.core import build_event_planning_workflow
 
 # Load environment variables at module import
 load_dotenv()
+
+# Enable observability (reads from environment variables)
+setup_observability()
 
 
 async def main() -> None:

--- a/src/spec_to_agents/main.py
+++ b/src/spec_to_agents/main.py
@@ -1,9 +1,13 @@
 # Copyright (c) Microsoft. All rights reserved.
 
+from agent_framework.observability import setup_observability
 from dotenv import load_dotenv
 
 # Load environment variables at module import
 load_dotenv()
+
+# Enable observability (reads from environment variables)
+setup_observability()
 
 
 def main() -> None:


### PR DESCRIPTION
This pull request adds OpenTelemetry-based observability support to the project. It introduces new environment variables and dependencies for telemetry, and ensures that observability is initialized at application startup in both the main and console entry points.

<img width="1943" height="1242" alt="CleanShot 2025-11-01 at 15 27 40" src="https://github.com/user-attachments/assets/8e29c179-553a-4f2b-84d2-167b8aa25f9f" />


**Observability and Telemetry Integration:**

* Added new environment variables in `.env.example` to configure OpenTelemetry and Azure Application Insights, such as `ENABLE_OTEL`, `ENABLE_SENSITIVE_DATA`, and `APPLICATIONINSIGHTS_CONNECTION_STRING`.
* Added OpenTelemetry and Azure Monitor dependencies to `pyproject.toml`, including `opentelemetry-api`, `opentelemetry-sdk`, `azure-monitor-opentelemetry`, and related packages.

**Application Initialization:**

* Imported and called `setup_observability()` from `agent_framework.observability` in both `src/spec_to_agents/main.py` and `src/spec_to_agents/console.py` to enable observability at startup, after loading environment variables. [[1]](diffhunk://#diff-54c2280aed6d534f804657734911aad6fd705d49fc29cb30e254599bc206f9d1R3-R11) [[2]](diffhunk://#diff-fcd5155f781c87053690a1b418fd5756a95e27f0f1fd4ed12144d244857be06bR29) [[3]](diffhunk://#diff-fcd5155f781c87053690a1b418fd5756a95e27f0f1fd4ed12144d244857be06bR49-R51)