### PR TITLE
Updates Dockerfile to use uv directly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,20 @@
-# Use the official uv image as builder
-FROM ghcr.io/astral-sh/uv:python3.11-bookworm-slim AS builder
+# Builder stage - use slim Python image
+FROM python:3.12-slim-bookworm AS builder
 
 # Set working directory
 WORKDIR /app
+
+# Install uv manually (following official installation)
+ARG UV_VERSION=0.5.11
+ENV UV_VERSION=${UV_VERSION}
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    ca-certificates \
+    && curl -LsSf https://astral.sh/uv/${UV_VERSION}/install.sh | sh \
+    && rm -rf /var/lib/apt/lists/*
+
+# Add uv to PATH
+ENV PATH="/root/.local/bin:$PATH"
 
 # Enable bytecode compilation for faster startup
 ENV UV_COMPILE_BYTECODE=1
@@ -22,20 +34,23 @@ COPY . /app
 RUN uv sync --frozen --no-dev
 
 # Final runtime stage - use slim Python image
-FROM python:3.11-slim-bookworm
+FROM python:3.12-slim-bookworm
 
 # Set working directory
 WORKDIR /app
 
-# Install Node.js (required for MCP tools)
-RUN apt-get update && apt-get install -y \
+# Install Node.js (required for MCP tools) and uv
+ENV UV_VERSION=0.5.11
+RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
+    ca-certificates \
     && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
-    && apt-get install -y nodejs \
+    && apt-get install -y --no-install-recommends nodejs \
+    && curl -LsSf https://astral.sh/uv/${UV_VERSION}/install.sh | sh \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy uv from the builder stage
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+# Add uv to PATH
+ENV PATH="/root/.local/bin:$PATH"
 
 # Copy the virtual environment from the builder
 COPY --from=builder /app/.venv /app/.venv


### PR DESCRIPTION
Updates the Dockerfile to install and use `uv` directly instead of relying on a pre-built image. This change involves:

- Upgrading the base Python image to 3.12.
- Manually installing `uv` in both the builder and final runtime stages.
- Ensuring `uv` is added to the PATH.
- Installing necessary dependencies like `curl` and `ca-certificates`.