### PR TITLE
fix(deps): pin a2a-sdk<0.3.24 and tighten dependency bounds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,21 +10,30 @@ dependencies = [
     "agent-framework-azure-ai==1.0.0b251111",
     "agent-framework-a2a==1.0.0b251111",
     "agent-framework-devui==1.0.0b251111",
-    "azure-identity>=1.25.0",
-    "python-dotenv>=1.1.1",
-    "httpx>=0.27.0",
-    "aiohttp>=3.9.0",
-    "icalendar>=5.0.11",
+    # Pin a2a-sdk to a compatible version; agent-framework-a2a 1.0.0b251111
+    # declares a2a-sdk>=0.3.5 without upper bound, but a2a-sdk>=0.3.24 removes
+    # FilePart/TextPart/FileWithBytes/FileWithUri causing ImportError.
+    # Upstream agent-framework pins a2a-sdk<0.3.24.
+    "a2a-sdk>=0.3.5,<0.3.24",
+    "azure-identity>=1.25.0,<2",
+    "python-dotenv>=1.1.1,<2",
+    "httpx>=0.27.0,<1",
+    "aiohttp>=3.9.0,<4",
+    "icalendar>=5.0.11,<8",
     "pytz>=2024.1",
-    "rich>=13.7.0",
-    # OpenTelemetry packages for observability
-    "opentelemetry-api",
-    "opentelemetry-sdk",
-    "azure-monitor-opentelemetry",
-    "azure-monitor-opentelemetry-exporter>=1.0.0b41",
-    "opentelemetry-exporter-otlp-proto-grpc",
-    "opentelemetry-semantic-conventions-ai",
-    "dependency-injector>=4.48.2",
+    "rich>=13.7.0,<16",
+    # OpenTelemetry packages for observability.
+    # Stable OTel APIs follow 1.x; pin <2 to avoid a future breaking major.
+    # Instrumentation/semantic-conventions still use 0.x betas; pin <1.
+    "opentelemetry-api>=1.30,<2",
+    "opentelemetry-sdk>=1.30,<2",
+    "azure-monitor-opentelemetry>=1.6,<2",
+    "azure-monitor-opentelemetry-exporter>=1.0.0b41,<2",
+    "opentelemetry-exporter-otlp-proto-grpc>=1.30,<2",
+    "opentelemetry-semantic-conventions-ai>=0.4,<1",
+    "dependency-injector>=4.48.2,<5",
+    # Pydantic 2.x pinned to avoid future v3 breakages.
+    "pydantic>=2.8,<3",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary

Fixes `ImportError: cannot import name 'FilePart' from 'a2a.types'` when running `uv run console` (or any entry point that imports `agent_framework.a2a`).

## Root cause

`a2a-sdk` 0.3.24+ (including 1.0.x) removed `FilePart`, `TextPart`, `FileWithBytes`, and `FileWithUri` from `a2a.types` as part of a migration to protobuf-generated types. However, `agent-framework-a2a==1.0.0b251111` declares:

```
Requires-Dist: a2a-sdk>=0.3.5
```

…with no upper bound, so fresh installs resolved `a2a-sdk==1.0.1` and crashed at import time inside `agent_framework_a2a._agent`.

Upstream [microsoft/agent-framework](https://github.com/microsoft/agent-framework/blob/main/python/packages/a2a/pyproject.toml) now pins `a2a-sdk>=0.3.5,<0.3.24`. This PR mirrors that constraint.

## Changes

- Pin `a2a-sdk>=0.3.5,<0.3.24` (mirrors upstream).
- Tighten previously unbounded / loosely bounded dependencies with caret-style upper bounds to prevent future breaking majors from silently regressing the build:
  - `azure-identity`, `python-dotenv`, `httpx`, `aiohttp`, `icalendar`, `rich`, `dependency-injector`
  - `opentelemetry-api`, `opentelemetry-sdk`, `opentelemetry-exporter-otlp-proto-grpc` → `>=1.30,<2`
  - `azure-monitor-opentelemetry`, `azure-monitor-opentelemetry-exporter` → `<2`
  - `opentelemetry-semantic-conventions-ai` → `<1`
  - Added explicit `pydantic>=2.8,<3`
- `pytz` left unbounded (release-date versioned, no breaking API).

## Verification

```
$ uv sync --dev
Resolved 159 packages in 0.88ms
Checked 154 packages in 1ms

$ uv run python -c 'from spec_to_agents.console import cli; print("OK")'
OK
```

`uv run console` now imports cleanly; the only remaining failure is the expected `AZURE_AI_PROJECT_ENDPOINT` check (Azure infra not yet provisioned, out of scope for this PR).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>